### PR TITLE
Reduce unhandled link shortening exceptions

### DIFF
--- a/pbincli/api.py
+++ b/pbincli/api.py
@@ -89,6 +89,9 @@ class Shortener:
     def __init__(self, settings=None):
         self.api = settings['short_api']
 
+        if self.api is None:
+            PBinCLIError("Unable to activate link shortener without short_api.")
+
         # we checking which service is used, because some services doesn't require
         # any authentication, or have only one domain on which it working
         if self.api == 'yourls':
@@ -256,6 +259,9 @@ class Shortener:
 
 
     def _custom(self, url):
+        if self.apiurl is None:
+            PBinCLIError("No short_url specified - link will not be shortened.")
+
         from urllib.parse import quote
         qUrl = quote(url, safe="") # urlencoded paste url
         rUrl = self.apiurl.replace("{{url}}", qUrl)


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter mail@georg-pfuetzenreuter.net

Hi,

I noticed the program would fail with an exception if the link shortening functions were called without a URL specified - there probably are other cases which I have not discovered, but the two error messages added with this patch should at least reduce the overall times it happens.